### PR TITLE
fix possible NRE on GoogleMusicSong.ArtURL.

### DIFF
--- a/GoogleMusicAPI.NET/Models.cs
+++ b/GoogleMusicAPI.NET/Models.cs
@@ -166,7 +166,7 @@ namespace GoogleMusicAPI
         {
             get
             {
-                return (!albumart.StartsWith("http:")) ? "http:" + albumart : albumart;
+                return (albumart != null && !albumart.StartsWith("http:")) ? "http:" + albumart : albumart;
             }
             set { albumart = value; }
         }


### PR DESCRIPTION
The issue was raised by mono DataContractJsonSerializer (could be raised by
any combination of FormatterServices.GetUninitializedObject() and whatever).
